### PR TITLE
Port to 1.19.2, minor additions/adaptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@
 /forge/.gradle/
 /forge/build/
 /forge/run/
-

--- a/common/src/main/java/com/akicater/ItemPlacerCommon.java
+++ b/common/src/main/java/com/akicater/ItemPlacerCommon.java
@@ -65,7 +65,7 @@ public class ItemPlacerCommon {
         Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
         Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
 
-        LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
+        LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.DECORATION).breakInstantly().nonOpaque()));
         LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
             new Identifier(MODID, "laying_item_block_entity"),
             () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)

--- a/common/src/main/java/com/akicater/ItemPlacerCommon.java
+++ b/common/src/main/java/com/akicater/ItemPlacerCommon.java
@@ -87,7 +87,7 @@ public class ItemPlacerCommon {
                 }
                 world.setBlockState(pos, state);
                 state.initShapeCache();
-                layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
                 if (blockEntity != null) {
                     int i = ItemPlacerCommon.dirToInt(dir);
                     blockEntity.inventory.set(i, stack);
@@ -96,10 +96,10 @@ public class ItemPlacerCommon {
                 }
             } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
                 Direction dir = hitResult.getSide().getOpposite();
-                layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
                 if (blockEntity != null) {
                     int i = ItemPlacerCommon.dirToInt(dir);
-                    if (blockEntity.inventory.get(i).isEmpty()) {
+                    if(blockEntity.inventory.get(i).isEmpty()) {
                         context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
                         blockEntity.inventory.set(i, stack);
                         world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
@@ -137,7 +137,7 @@ public class ItemPlacerCommon {
                     }
                     world.setBlockState(pos, state);
                     state.initShapeCache();
-                    layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                    layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
                     if (blockEntity != null) {
                         int i = ItemPlacerCommon.dirToInt(dir);
                         blockEntity.inventory.set(i, stack);
@@ -146,10 +146,10 @@ public class ItemPlacerCommon {
                     }
                 } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
                     Direction dir = hitResult.getSide().getOpposite();
-                    layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                    layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
                     if (blockEntity != null) {
                         int i = ItemPlacerCommon.dirToInt(dir);
-                        if (blockEntity.inventory.get(i).isEmpty()) {
+                        if(blockEntity.inventory.get(i).isEmpty()) {
                             context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
                             blockEntity.inventory.set(i, stack);
                             world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
@@ -266,7 +266,7 @@ public class ItemPlacerCommon {
         double y = Math.abs(yT - blockPos.getY());
         double z = Math.abs(zT - blockPos.getZ());
 
-        Vec3d pos = new Vec3d(x, y, z);
+        Vec3d pos = new Vec3d(x,y,z);
 
         for (int i = 0; i < boxes.size(); i++) {
             if (contains(pos, boxes.get(i))) {

--- a/common/src/main/java/com/akicater/ItemPlacerCommon.java
+++ b/common/src/main/java/com/akicater/ItemPlacerCommon.java
@@ -43,35 +43,87 @@ import java.util.function.Supplier;
 
 public class ItemPlacerCommon {
     public static final Logger LOGGER = LoggerFactory.getLogger("item-placer");
-        public static String MODID = "item-placer";
+    public static String MODID = "item-placer";
 
-        public static Supplier<Registries> MANAGER;
+    public static Supplier<Registries> MANAGER;
 
-        public static RegistrySupplier<Block> LAYING_ITEM;
-        public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
+    public static RegistrySupplier<Block> LAYING_ITEM;
+    public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
 
-        public static Identifier ITEMPLACE;
-        public static Identifier ITEMROTATE;
+    public static Identifier ITEMPLACE;
+    public static Identifier ITEMROTATE;
 
-        public static KeyBinding PLACE_KEY;
-        public static KeyBinding STOP_SCROLLING_KEY;
-        public static KeyBinding RETRIEVE_KEY;
 
-        public static void initializeServer() {
-            if (Platform.isForge()) MODID = "itemplacer";
+    public static KeyBinding PLACE_KEY;
+    public static KeyBinding STOP_SCROLLING_KEY;
+    public static KeyBinding RETRIEVE_KEY;
 
-            MANAGER = Suppliers.memoize(() -> Registries.get(MODID));
-            Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
-            Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
+    public static void initializeServer() {
+        if (Platform.isForge()) MODID = "itemplacer";
 
-            LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
-            LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
-                new Identifier(MODID, "laying_item_block_entity"),
-                () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
-            );
+        MANAGER = Suppliers.memoize(() -> Registries.get(MODID));
+        Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
+        Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
 
-            ITEMPLACE = new Identifier(MODID, "itemplace");
-            ITEMROTATE = new Identifier(MODID, "itemrotate");
+        LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
+        LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
+            new Identifier(MODID, "laying_item_block_entity"),
+            () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
+        );
+
+        ITEMPLACE = new Identifier(MODID, "itemplace");
+        ITEMROTATE = new Identifier(MODID, "itemrotate");
+
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
+            ItemStack stack = context.getPlayer().getMainHandStack();
+            World world = context.getPlayer().getWorld();
+            BlockPos pos = buf.readBlockPos();
+            BlockHitResult hitResult = buf.readBlockHitResult();
+            if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                Direction dir = hitResult.getSide().getOpposite();
+                BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
+                if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                    state = state.with(Properties.WATERLOGGED, true);
+                }
+                world.setBlockState(pos, state);
+                state.initShapeCache();
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
+                if (blockEntity != null) {
+                    int i = ItemPlacerCommon.dirToInt(dir);
+                    blockEntity.inventory.set(i, stack);
+                    world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                    blockEntity.markDirty();
+                }
+            } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
+                Direction dir = hitResult.getSide().getOpposite();
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
+                if (blockEntity != null) {
+                    int i = ItemPlacerCommon.dirToInt(dir);
+                    if(blockEntity.inventory.get(i).isEmpty()) {
+                        context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                        blockEntity.inventory.set(i, stack);
+                        world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                        blockEntity.markDirty();
+                    }
+                }
+            }
+        });
+
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
+            BlockPos pos = buf.readBlockPos();
+            World world = context.getPlayer().getEntityWorld();
+            BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
+            if (blockEntity instanceof layingItemBlockEntity) {
+                ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
+            }
+        });
+
+    }
+
+    public static void initializeClient() {
+        if (Platform.isForge()) {
+            MODID = "itemplacer";
 
             NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
                 ItemStack stack = context.getPlayer().getMainHandStack();
@@ -119,161 +171,110 @@ public class ItemPlacerCommon {
             });
         }
 
-        public static void initializeClient() {
-            if (Platform.isForge()) {
-                MODID = "itemplacer";
+        ITEMPLACE = new Identifier(MODID, "itemplace");
+        ITEMROTATE = new Identifier(MODID, "itemrotate");
 
-                NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
-                    ItemStack stack = context.getPlayer().getMainHandStack();
-                    World world = context.getPlayer().getWorld();
-                    BlockPos pos = buf.readBlockPos();
-                    BlockHitResult hitResult = buf.readBlockHitResult();
-                    if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
-                        context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-                        Direction dir = hitResult.getSide().getOpposite();
-                        BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
-                        if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
-                            state = state.with(Properties.WATERLOGGED, true);
-                        }
-                        world.setBlockState(pos, state);
-                        state.initShapeCache();
-                        layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-                        if (blockEntity != null) {
-                            int i = ItemPlacerCommon.dirToInt(dir);
-                            blockEntity.inventory.set(i, stack);
-                            world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-                            blockEntity.markDirty();
-                        }
-                    } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
-                        Direction dir = hitResult.getSide().getOpposite();
-                        layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-                        if (blockEntity != null) {
-                            int i = ItemPlacerCommon.dirToInt(dir);
-                            if(blockEntity.inventory.get(i).isEmpty()) {
-                                context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-                                blockEntity.inventory.set(i, stack);
-                                world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-                                blockEntity.markDirty();
-                            }
-                        }
-                    }
-                });
-
-                NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
-                    BlockPos pos = buf.readBlockPos();
-                    World world = context.getPlayer().getEntityWorld();
-                    BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
-                    if (blockEntity instanceof layingItemBlockEntity) {
-                        ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
-                    }
-                });
-            }
-
-            ITEMPLACE = new Identifier(MODID, "itemplace");
-            ITEMROTATE = new Identifier(MODID, "itemrotate");
-
-            PLACE_KEY = new KeyBinding(
-                "Place item",
-                InputUtil.Type.KEYSYM,
-                GLFW.GLFW_KEY_V,
-                "item-placer"
-            );
-
-            STOP_SCROLLING_KEY = new KeyBinding(
-                "Rotate item",
-                InputUtil.Type.KEYSYM,
-                GLFW.GLFW_KEY_LEFT_ALT,
-                "item-placer"
-            );
-
-            RETRIEVE_KEY = new KeyBinding(
-                "Retrieve item",
-                InputUtil.Type.KEYSYM,
-                GLFW.GLFW_KEY_UNKNOWN,
-                "item-placer"
-            );
-
-
-            KeyMappingRegistry.register(PLACE_KEY);
-            KeyMappingRegistry.register(STOP_SCROLLING_KEY);
-            KeyMappingRegistry.register(RETRIEVE_KEY);
-
-            ClientTickEvent.CLIENT_POST.register(client -> {
-                if (PLACE_KEY.wasPressed()) {
-                    if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
-                        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-                        Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
-                        BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
-                        buf.writeBlockPos(pos.offset(side, 1));
-                        buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
-                        NetworkManager.sendToServer(ITEMPLACE, buf);
-                    }
-                }
-            });
-        }
-
-        public static int dirToInt(Direction dir) {
-            return switch (dir) {
-                case SOUTH -> 0;
-                case NORTH -> 1;
-                case EAST -> 2;
-                case WEST -> 3;
-                case UP -> 4;
-                case DOWN -> 5;
-            };
-        }
-
-        public static Direction intToDir(int dir) {
-            return switch (dir) {
-                case 0 -> Direction.SOUTH;
-                case 1 -> Direction.NORTH;
-                case 2 -> Direction.EAST;
-                case 3 -> Direction.WEST;
-                case 4 -> Direction.UP;
-                case 5 -> Direction.DOWN;
-                default -> throw new IllegalStateException("Unexpected value: " + dir);
-            };
-        }
-
-        static boolean contains(Vec3d vec, Box box) {
-            return vec.x >= box.minX
-                && vec.x <= box.maxX
-                && vec.y >= box.minY
-                && vec.y <= box.maxY
-                && vec.z >= box.minZ
-                && vec.z <= box.maxZ;
-        }
-
-        static List<Box> boxes = new ArrayList<>(
-            List.of(
-                new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
-                new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
-                new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
-                new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
-                new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
-                new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
-            )
+        PLACE_KEY = new KeyBinding(
+            "Place item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_V,
+            "item-placer"
         );
 
-        public static int getDirection(BlockHitResult hit) {
-            double xT = hit.getPos().x;
-            double yT = hit.getPos().y;
-            double zT = hit.getPos().z;
+        STOP_SCROLLING_KEY = new KeyBinding(
+            "Rotate item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_LEFT_ALT,
+            "item-placer"
+        );
 
-            BlockPos blockPos = hit.getBlockPos();
+        RETRIEVE_KEY = new KeyBinding(
+            "Retrieve item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_UNKNOWN,
+            "item-placer"
+        );
 
-            double x = Math.abs(xT - blockPos.getX());
-            double y = Math.abs(yT - blockPos.getY());
-            double z = Math.abs(zT - blockPos.getZ());
+        KeyMappingRegistry.register(PLACE_KEY);
+        KeyMappingRegistry.register(STOP_SCROLLING_KEY);
+        KeyMappingRegistry.register(RETRIEVE_KEY);
 
-            Vec3d pos = new Vec3d(x,y,z);
-
-            for (int i = 0; i < boxes.size(); i++) {
-                if (contains(pos, boxes.get(i))) {
-                    return i;
+        ClientTickEvent.CLIENT_POST.register(client -> {
+            if (PLACE_KEY.wasPressed()) {
+                if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
+                    PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+                    Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
+                    BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
+                    buf.writeBlockPos(pos.offset(side, 1));
+                    buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
+                    NetworkManager.sendToServer(ITEMPLACE, buf);
                 }
             }
-            LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
-            return 0;
+        });
+    }
+
+    public static int dirToInt(Direction dir) {
+        return switch (dir) {
+            case SOUTH -> 0;
+            case NORTH -> 1;
+            case EAST -> 2;
+            case WEST -> 3;
+            case UP -> 4;
+            case DOWN -> 5;
+        };
+    }
+
+    public static Direction intToDir(int dir) {
+        return switch (dir) {
+            case 0 -> Direction.SOUTH;
+            case 1 -> Direction.NORTH;
+            case 2 -> Direction.EAST;
+            case 3 -> Direction.WEST;
+            case 4 -> Direction.UP;
+            case 5 -> Direction.DOWN;
+            default -> throw new IllegalStateException("Unexpected value: " + dir);
+        };
+    }
+
+    static boolean contains(Vec3d vec, Box box) {
+        return vec.x >= box.minX
+            && vec.x <= box.maxX
+            && vec.y >= box.minY
+            && vec.y <= box.maxY
+            && vec.z >= box.minZ
+            && vec.z <= box.maxZ;
+    }
+
+    static List<Box> boxes = new ArrayList<>(
+        List.of(
+            new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
+            new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
+            new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
+            new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
+            new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
+            new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
+        )
+    );
+
+    public static int getDirection(BlockHitResult hit) {
+        double xT = hit.getPos().x;
+        double yT = hit.getPos().y;
+        double zT = hit.getPos().z;
+
+        BlockPos blockPos = hit.getBlockPos();
+
+        double x = Math.abs(xT - blockPos.getX());
+        double y = Math.abs(yT - blockPos.getY());
+        double z = Math.abs(zT - blockPos.getZ());
+
+        Vec3d pos = new Vec3d(x,y,z);
+
+        for (int i = 0; i < boxes.size(); i++) {
+            if (contains(pos, boxes.get(i))) {
+                return i;
+            }
         }
+        LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
+        return 0;
+    }
 }

--- a/common/src/main/java/com/akicater/ItemPlacerCommon.java
+++ b/common/src/main/java/com/akicater/ItemPlacerCommon.java
@@ -8,21 +8,20 @@ import dev.architectury.networking.NetworkManager;
 import dev.architectury.platform.Platform;
 import dev.architectury.registry.client.keymappings.KeyMappingRegistry;
 import dev.architectury.registry.registries.Registrar;
-import dev.architectury.registry.registries.RegistrarManager;
+import dev.architectury.registry.registries.Registries;
 import dev.architectury.registry.registries.RegistrySupplier;
 import io.netty.buffer.Unpooled;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.Material;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.block.piston.PistonBehavior;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
-import net.minecraft.registry.Registries;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
@@ -31,6 +30,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
 import org.lwjgl.glfw.GLFW;
@@ -43,229 +43,237 @@ import java.util.function.Supplier;
 
 public class ItemPlacerCommon {
     public static final Logger LOGGER = LoggerFactory.getLogger("item-placer");
-	public static String MODID = "item-placer";
+    public static String MODID = "item-placer";
 
-	public static Supplier<RegistrarManager> MANAGER;
+    public static Supplier<Registries> MANAGER;
 
-	public static RegistrySupplier<Block> LAYING_ITEM;
-	public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
+    public static RegistrySupplier<Block> LAYING_ITEM;
+    public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
 
-	public static Identifier ITEMPLACE;
-	public static Identifier ITEMROTATE;
+    public static Identifier ITEMPLACE;
+    public static Identifier ITEMROTATE;
+
+    public static KeyBinding PLACE_KEY;
+    public static KeyBinding STOP_SCROLLING_KEY;
+    public static KeyBinding RETRIEVE_KEY;
+
+    public static void initializeServer() {
+        if (Platform.isForge()) MODID = "itemplacer";
+
+        MANAGER = Suppliers.memoize(() -> Registries.get(MODID));
+        Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
+        Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
+
+        LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
+        LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
+            new Identifier(MODID, "laying_item_block_entity"),
+            () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
+        );
+
+        ITEMPLACE = new Identifier(MODID, "itemplace");
+        ITEMROTATE = new Identifier(MODID, "itemrotate");
+
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
+            ItemStack stack = context.getPlayer().getMainHandStack();
+            World world = context.getPlayer().getWorld();
+            BlockPos pos = buf.readBlockPos();
+            BlockHitResult hitResult = buf.readBlockHitResult();
+            if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                Direction dir = hitResult.getSide().getOpposite();
+                BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
+                if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                    state = state.with(Properties.WATERLOGGED, true);
+                }
+                world.setBlockState(pos, state);
+                state.initShapeCache();
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                if (blockEntity != null) {
+                    int i = ItemPlacerCommon.dirToInt(dir);
+                    blockEntity.inventory.set(i, stack);
+                    world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                    blockEntity.markDirty();
+                }
+            } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
+                Direction dir = hitResult.getSide().getOpposite();
+                layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                if (blockEntity != null) {
+                    int i = ItemPlacerCommon.dirToInt(dir);
+                    if (blockEntity.inventory.get(i).isEmpty()) {
+                        context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                        blockEntity.inventory.set(i, stack);
+                        world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                        blockEntity.markDirty();
+                    }
+                }
+            }
+        });
+
+        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
+            BlockPos pos = buf.readBlockPos();
+            World world = context.getPlayer().getEntityWorld();
+            BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
+            if (blockEntity instanceof layingItemBlockEntity) {
+                ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
+            }
+        });
+    }
+
+    public static void initializeClient() {
+        if (Platform.isForge()) {
+            MODID = "itemplacer";
+
+            NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
+                ItemStack stack = context.getPlayer().getMainHandStack();
+                World world = context.getPlayer().getWorld();
+                BlockPos pos = buf.readBlockPos();
+                BlockHitResult hitResult = buf.readBlockHitResult();
+                if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                    context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                    Direction dir = hitResult.getSide().getOpposite();
+                    BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
+                    if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                        state = state.with(Properties.WATERLOGGED, true);
+                    }
+                    world.setBlockState(pos, state);
+                    state.initShapeCache();
+                    layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                    if (blockEntity != null) {
+                        int i = ItemPlacerCommon.dirToInt(dir);
+                        blockEntity.inventory.set(i, stack);
+                        world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                        blockEntity.markDirty();
+                    }
+                } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
+                    Direction dir = hitResult.getSide().getOpposite();
+                    layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+                    if (blockEntity != null) {
+                        int i = ItemPlacerCommon.dirToInt(dir);
+                        if (blockEntity.inventory.get(i).isEmpty()) {
+                            context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                            blockEntity.inventory.set(i, stack);
+                            world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                            blockEntity.markDirty();
+                        }
+                    }
+                }
+            });
+
+            NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
+                BlockPos pos = buf.readBlockPos();
+                World world = context.getPlayer().getEntityWorld();
+                BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
+                if (blockEntity instanceof layingItemBlockEntity) {
+                    ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
+                }
+            });
+        }
+
+        ITEMPLACE = new Identifier(MODID, "itemplace");
+        ITEMROTATE = new Identifier(MODID, "itemrotate");
+
+        PLACE_KEY = new KeyBinding(
+            "Place item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_V,
+            "item-placer"
+        );
+
+        STOP_SCROLLING_KEY = new KeyBinding(
+            "Rotate item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_LEFT_ALT,
+            "item-placer"
+        );
+
+        RETRIEVE_KEY = new KeyBinding(
+            "Retrieve item",
+            InputUtil.Type.KEYSYM,
+            GLFW.GLFW_KEY_UNKNOWN,
+            "item-placer"
+        );
 
 
-	public static KeyBinding PLACE_KEY;
-	public static KeyBinding STOP_SCROLLING_KEY;
+        KeyMappingRegistry.register(PLACE_KEY);
+        KeyMappingRegistry.register(STOP_SCROLLING_KEY);
+        KeyMappingRegistry.register(RETRIEVE_KEY);
 
-	public static void initializeServer() {
-		if (Platform.isForge()) MODID = "itemplacer";
+        ClientTickEvent.CLIENT_POST.register(client -> {
+            if (PLACE_KEY.wasPressed()) {
+                if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
+                    PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+                    Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
+                    BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
+                    buf.writeBlockPos(pos.offset(side, 1));
+                    buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
+                    NetworkManager.sendToServer(ITEMPLACE, buf);
+                }
+            }
+        });
+    }
 
-		MANAGER = Suppliers.memoize(() -> RegistrarManager.get(MODID));
-		Registrar<Block> blocks = MANAGER.get().get(Registries.BLOCK);
-		Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registries.BLOCK_ENTITY_TYPE);
+    public static int dirToInt(Direction dir) {
+        return switch (dir) {
+            case SOUTH -> 0;
+            case NORTH -> 1;
+            case EAST -> 2;
+            case WEST -> 3;
+            case UP -> 4;
+            case DOWN -> 5;
+        };
+    }
 
-		LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.create().breakInstantly().nonOpaque().noBlockBreakParticles().pistonBehavior(PistonBehavior.DESTROY)));
-		LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
-				new Identifier(MODID, "laying_item_block_entity"),
-				() -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
-		);
+    public static Direction intToDir(int dir) {
+        return switch (dir) {
+            case 0 -> Direction.SOUTH;
+            case 1 -> Direction.NORTH;
+            case 2 -> Direction.EAST;
+            case 3 -> Direction.WEST;
+            case 4 -> Direction.UP;
+            case 5 -> Direction.DOWN;
+            default -> throw new IllegalStateException("Unexpected value: " + dir);
+        };
+    }
 
-		ITEMPLACE = new Identifier(MODID, "itemplace");
-		ITEMROTATE = new Identifier(MODID, "itemrotate");
+    static boolean contains(Vec3d vec, Box box) {
+        return vec.x >= box.minX
+            && vec.x <= box.maxX
+            && vec.y >= box.minY
+            && vec.y <= box.maxY
+            && vec.z >= box.minZ
+            && vec.z <= box.maxZ;
+    }
 
-		NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
-			ItemStack stack = context.getPlayer().getMainHandStack();
-			World world = context.getPlayer().getWorld();
-			BlockPos pos = buf.readBlockPos();
-			BlockHitResult hitResult = buf.readBlockHitResult();
-			if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
-				context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-				Direction dir = hitResult.getSide().getOpposite();
-				BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
-				if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
-					state = state.with(Properties.WATERLOGGED, true);
-				}
-				world.setBlockState(pos, state);
-				state.initShapeCache();
-				layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-				if (blockEntity != null) {
-					int i = ItemPlacerCommon.dirToInt(dir);
-					blockEntity.inventory.set(i, stack);
-					world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-					blockEntity.markDirty();
-				}
-			} else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
-				Direction dir = hitResult.getSide().getOpposite();
-				layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-				if (blockEntity != null) {
-					int i = ItemPlacerCommon.dirToInt(dir);
-					if(blockEntity.inventory.get(i).isEmpty()) {
-						context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-						blockEntity.inventory.set(i, stack);
-						world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-						blockEntity.markDirty();
-					}
-				}
-			}
-		});
+    static List<Box> boxes = new ArrayList<>(
+        List.of(
+            new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
+            new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
+            new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
+            new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
+            new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
+            new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
+        )
+    );
 
-		NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
-			BlockPos pos = buf.readBlockPos();
-			World world = context.getPlayer().getEntityWorld();
-			BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
-			if (blockEntity instanceof layingItemBlockEntity) {
-				((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
-			}
-		});
+    public static int getDirection(BlockHitResult hit) {
+        double xT = hit.getPos().x;
+        double yT = hit.getPos().y;
+        double zT = hit.getPos().z;
 
-	}
+        BlockPos blockPos = hit.getBlockPos();
 
-	public static void initializeClient() {
-		if (Platform.isForge()) {
-			MODID = "itemplacer";
+        double x = Math.abs(xT - blockPos.getX());
+        double y = Math.abs(yT - blockPos.getY());
+        double z = Math.abs(zT - blockPos.getZ());
 
-			NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
-				ItemStack stack = context.getPlayer().getMainHandStack();
-				World world = context.getPlayer().getWorld();
-				BlockPos pos = buf.readBlockPos();
-				BlockHitResult hitResult = buf.readBlockHitResult();
-				if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
-					context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-					Direction dir = hitResult.getSide().getOpposite();
-					BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
-					if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
-						state = state.with(Properties.WATERLOGGED, true);
-					}
-					world.setBlockState(pos, state);
-					state.initShapeCache();
-					layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-					if (blockEntity != null) {
-						int i = ItemPlacerCommon.dirToInt(dir);
-						blockEntity.inventory.set(i, stack);
-						world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-						blockEntity.markDirty();
-					}
-				} else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
-					Direction dir = hitResult.getSide().getOpposite();
-					layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-					if (blockEntity != null) {
-						int i = ItemPlacerCommon.dirToInt(dir);
-						if(blockEntity.inventory.get(i).isEmpty()) {
-							context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-							blockEntity.inventory.set(i, stack);
-							world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-							blockEntity.markDirty();
-						}
-					}
-				}
-			});
+        Vec3d pos = new Vec3d(x, y, z);
 
-			NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
-				BlockPos pos = buf.readBlockPos();
-				World world = context.getPlayer().getEntityWorld();
-				BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
-				if (blockEntity instanceof layingItemBlockEntity) {
-					((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
-				}
-			});
-		}
-
-		ITEMPLACE = new Identifier(MODID, "itemplace");
-		ITEMROTATE = new Identifier(MODID, "itemrotate");
-
-		PLACE_KEY = new KeyBinding(
-				"Place item",
-				InputUtil.Type.KEYSYM,
-				GLFW.GLFW_KEY_V,
-				"item-placer"
-		);
-
-		STOP_SCROLLING_KEY = new KeyBinding(
-				"Rotate item",
-				InputUtil.Type.KEYSYM,
-				GLFW.GLFW_KEY_LEFT_ALT,
-				"item-placer"
-		);
-
-		KeyMappingRegistry.register(PLACE_KEY);
-		KeyMappingRegistry.register(STOP_SCROLLING_KEY);
-
-		ClientTickEvent.CLIENT_POST.register(client -> {
-			if (PLACE_KEY.wasPressed()) {
-				if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
-					PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-					Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
-					BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
-					buf.writeBlockPos(pos.offset(side, 1));
-					buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
-					NetworkManager.sendToServer(ITEMPLACE, buf);
-				}
-			}
-		});
-	}
-
-	public static int dirToInt(Direction dir) {
-		return switch (dir) {
-			case SOUTH -> 0;
-			case NORTH -> 1;
-			case EAST -> 2;
-			case WEST -> 3;
-			case UP -> 4;
-			case DOWN -> 5;
-		};
-	}
-
-	public static Direction intToDir(int dir) {
-		return switch (dir) {
-			case 0 -> Direction.SOUTH;
-			case 1 -> Direction.NORTH;
-			case 2 -> Direction.EAST;
-			case 3 -> Direction.WEST;
-			case 4 -> Direction.UP;
-			case 5 -> Direction.DOWN;
-			default -> throw new IllegalStateException("Unexpected value: " + dir);
-		};
-	}
-
-	static boolean contains(Vec3d vec, Box box) {
-		return vec.x >= box.minX
-				&& vec.x <= box.maxX
-				&& vec.y >= box.minY
-				&& vec.y <= box.maxY
-				&& vec.z >= box.minZ
-				&& vec.z <= box.maxZ;
-	}
-
-	static List<Box> boxes = new ArrayList<>(
-			List.of(
-					new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
-					new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
-					new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
-					new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
-					new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
-					new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
-			)
-	);
-
-	public static int getDirection(BlockHitResult hit) {
-		double xT = hit.getPos().x;
-		double yT = hit.getPos().y;
-		double zT = hit.getPos().z;
-
-		BlockPos blockPos = hit.getBlockPos();
-
-		double x = Math.abs(xT - blockPos.getX());
-		double y = Math.abs(yT - blockPos.getY());
-		double z = Math.abs(zT - blockPos.getZ());
-
-		Vec3d pos = new Vec3d(x,y,z);
-
-		for (int i = 0; i < boxes.size(); i++) {
-			if (contains(pos, boxes.get(i))) {
-				return i;
-			}
-		}
-		LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
-		return 0;
-	}
+        for (int i = 0; i < boxes.size(); i++) {
+            if (contains(pos, boxes.get(i))) {
+                return i;
+            }
+        }
+        LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
+        return 0;
+    }
 }

--- a/common/src/main/java/com/akicater/ItemPlacerCommon.java
+++ b/common/src/main/java/com/akicater/ItemPlacerCommon.java
@@ -43,85 +43,35 @@ import java.util.function.Supplier;
 
 public class ItemPlacerCommon {
     public static final Logger LOGGER = LoggerFactory.getLogger("item-placer");
-    public static String MODID = "item-placer";
+        public static String MODID = "item-placer";
 
-    public static Supplier<Registries> MANAGER;
+        public static Supplier<Registries> MANAGER;
 
-    public static RegistrySupplier<Block> LAYING_ITEM;
-    public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
+        public static RegistrySupplier<Block> LAYING_ITEM;
+        public static RegistrySupplier<BlockEntityType<layingItemBlockEntity>> LAYING_ITEM_BLOCK_ENTITY;
 
-    public static Identifier ITEMPLACE;
-    public static Identifier ITEMROTATE;
+        public static Identifier ITEMPLACE;
+        public static Identifier ITEMROTATE;
 
-    public static KeyBinding PLACE_KEY;
-    public static KeyBinding STOP_SCROLLING_KEY;
-    public static KeyBinding RETRIEVE_KEY;
+        public static KeyBinding PLACE_KEY;
+        public static KeyBinding STOP_SCROLLING_KEY;
+        public static KeyBinding RETRIEVE_KEY;
 
-    public static void initializeServer() {
-        if (Platform.isForge()) MODID = "itemplacer";
+        public static void initializeServer() {
+            if (Platform.isForge()) MODID = "itemplacer";
 
-        MANAGER = Suppliers.memoize(() -> Registries.get(MODID));
-        Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
-        Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
+            MANAGER = Suppliers.memoize(() -> Registries.get(MODID));
+            Registrar<Block> blocks = MANAGER.get().get(Registry.BLOCK_KEY);
+            Registrar<BlockEntityType<?>> blockEntityTypes = MANAGER.get().get(Registry.BLOCK_ENTITY_TYPE_KEY);
 
-        LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
-        LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
-            new Identifier(MODID, "laying_item_block_entity"),
-            () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
-        );
+            LAYING_ITEM = blocks.register(new Identifier(MODID, "laying_item"), () -> new layingItem(Block.Settings.of(Material.AIR).breakInstantly().nonOpaque()));
+            LAYING_ITEM_BLOCK_ENTITY = blockEntityTypes.register(
+                new Identifier(MODID, "laying_item_block_entity"),
+                () -> BlockEntityType.Builder.create(layingItemBlockEntity::new, LAYING_ITEM.get()).build(null)
+            );
 
-        ITEMPLACE = new Identifier(MODID, "itemplace");
-        ITEMROTATE = new Identifier(MODID, "itemrotate");
-
-        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
-            ItemStack stack = context.getPlayer().getMainHandStack();
-            World world = context.getPlayer().getWorld();
-            BlockPos pos = buf.readBlockPos();
-            BlockHitResult hitResult = buf.readBlockHitResult();
-            if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
-                context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-                Direction dir = hitResult.getSide().getOpposite();
-                BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
-                if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
-                    state = state.with(Properties.WATERLOGGED, true);
-                }
-                world.setBlockState(pos, state);
-                state.initShapeCache();
-                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-                if (blockEntity != null) {
-                    int i = ItemPlacerCommon.dirToInt(dir);
-                    blockEntity.inventory.set(i, stack);
-                    world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-                    blockEntity.markDirty();
-                }
-            } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
-                Direction dir = hitResult.getSide().getOpposite();
-                layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-                if (blockEntity != null) {
-                    int i = ItemPlacerCommon.dirToInt(dir);
-                    if(blockEntity.inventory.get(i).isEmpty()) {
-                        context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
-                        blockEntity.inventory.set(i, stack);
-                        world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
-                        blockEntity.markDirty();
-                    }
-                }
-            }
-        });
-
-        NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
-            BlockPos pos = buf.readBlockPos();
-            World world = context.getPlayer().getEntityWorld();
-            BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
-            if (blockEntity instanceof layingItemBlockEntity) {
-                ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
-            }
-        });
-    }
-
-    public static void initializeClient() {
-        if (Platform.isForge()) {
-            MODID = "itemplacer";
+            ITEMPLACE = new Identifier(MODID, "itemplace");
+            ITEMROTATE = new Identifier(MODID, "itemrotate");
 
             NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
                 ItemStack stack = context.getPlayer().getMainHandStack();
@@ -169,111 +119,161 @@ public class ItemPlacerCommon {
             });
         }
 
-        ITEMPLACE = new Identifier(MODID, "itemplace");
-        ITEMROTATE = new Identifier(MODID, "itemrotate");
+        public static void initializeClient() {
+            if (Platform.isForge()) {
+                MODID = "itemplacer";
 
-        PLACE_KEY = new KeyBinding(
-            "Place item",
-            InputUtil.Type.KEYSYM,
-            GLFW.GLFW_KEY_V,
-            "item-placer"
+                NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMPLACE, (buf, context) -> {
+                    ItemStack stack = context.getPlayer().getMainHandStack();
+                    World world = context.getPlayer().getWorld();
+                    BlockPos pos = buf.readBlockPos();
+                    BlockHitResult hitResult = buf.readBlockHitResult();
+                    if (world.getBlockState(pos).getBlock() == Blocks.AIR || world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                        context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                        Direction dir = hitResult.getSide().getOpposite();
+                        BlockState state = ItemPlacerCommon.LAYING_ITEM.get().getDefaultState();
+                        if (world.getBlockState(pos).getBlock() == Blocks.WATER) {
+                            state = state.with(Properties.WATERLOGGED, true);
+                        }
+                        world.setBlockState(pos, state);
+                        state.initShapeCache();
+                        layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
+                        if (blockEntity != null) {
+                            int i = ItemPlacerCommon.dirToInt(dir);
+                            blockEntity.inventory.set(i, stack);
+                            world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                            blockEntity.markDirty();
+                        }
+                    } else if (world.getBlockState(pos).getBlock() == ItemPlacerCommon.LAYING_ITEM.get()) {
+                        Direction dir = hitResult.getSide().getOpposite();
+                        layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
+                        if (blockEntity != null) {
+                            int i = ItemPlacerCommon.dirToInt(dir);
+                            if(blockEntity.inventory.get(i).isEmpty()) {
+                                context.getPlayer().setStackInHand(Hand.MAIN_HAND, ItemStack.EMPTY);
+                                blockEntity.inventory.set(i, stack);
+                                world.emitGameEvent(context.getPlayer(), GameEvent.BLOCK_CHANGE, pos);
+                                blockEntity.markDirty();
+                            }
+                        }
+                    }
+                });
+
+                NetworkManager.registerReceiver(NetworkManager.Side.C2S, ITEMROTATE, (buf, context) -> {
+                    BlockPos pos = buf.readBlockPos();
+                    World world = context.getPlayer().getEntityWorld();
+                    BlockEntity blockEntity = world.getChunk(pos).getBlockEntity(pos);
+                    if (blockEntity instanceof layingItemBlockEntity) {
+                        ((layingItemBlockEntity) blockEntity).rotate(buf.readFloat(), getDirection(buf.readBlockHitResult()));
+                    }
+                });
+            }
+
+            ITEMPLACE = new Identifier(MODID, "itemplace");
+            ITEMROTATE = new Identifier(MODID, "itemrotate");
+
+            PLACE_KEY = new KeyBinding(
+                "Place item",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_V,
+                "item-placer"
+            );
+
+            STOP_SCROLLING_KEY = new KeyBinding(
+                "Rotate item",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_LEFT_ALT,
+                "item-placer"
+            );
+
+            RETRIEVE_KEY = new KeyBinding(
+                "Retrieve item",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_UNKNOWN,
+                "item-placer"
+            );
+
+
+            KeyMappingRegistry.register(PLACE_KEY);
+            KeyMappingRegistry.register(STOP_SCROLLING_KEY);
+            KeyMappingRegistry.register(RETRIEVE_KEY);
+
+            ClientTickEvent.CLIENT_POST.register(client -> {
+                if (PLACE_KEY.wasPressed()) {
+                    if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
+                        PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
+                        Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
+                        BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
+                        buf.writeBlockPos(pos.offset(side, 1));
+                        buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
+                        NetworkManager.sendToServer(ITEMPLACE, buf);
+                    }
+                }
+            });
+        }
+
+        public static int dirToInt(Direction dir) {
+            return switch (dir) {
+                case SOUTH -> 0;
+                case NORTH -> 1;
+                case EAST -> 2;
+                case WEST -> 3;
+                case UP -> 4;
+                case DOWN -> 5;
+            };
+        }
+
+        public static Direction intToDir(int dir) {
+            return switch (dir) {
+                case 0 -> Direction.SOUTH;
+                case 1 -> Direction.NORTH;
+                case 2 -> Direction.EAST;
+                case 3 -> Direction.WEST;
+                case 4 -> Direction.UP;
+                case 5 -> Direction.DOWN;
+                default -> throw new IllegalStateException("Unexpected value: " + dir);
+            };
+        }
+
+        static boolean contains(Vec3d vec, Box box) {
+            return vec.x >= box.minX
+                && vec.x <= box.maxX
+                && vec.y >= box.minY
+                && vec.y <= box.maxY
+                && vec.z >= box.minZ
+                && vec.z <= box.maxZ;
+        }
+
+        static List<Box> boxes = new ArrayList<>(
+            List.of(
+                new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
+                new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
+                new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
+                new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
+                new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
+                new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
+            )
         );
 
-        STOP_SCROLLING_KEY = new KeyBinding(
-            "Rotate item",
-            InputUtil.Type.KEYSYM,
-            GLFW.GLFW_KEY_LEFT_ALT,
-            "item-placer"
-        );
+        public static int getDirection(BlockHitResult hit) {
+            double xT = hit.getPos().x;
+            double yT = hit.getPos().y;
+            double zT = hit.getPos().z;
 
-        RETRIEVE_KEY = new KeyBinding(
-            "Retrieve item",
-            InputUtil.Type.KEYSYM,
-            GLFW.GLFW_KEY_UNKNOWN,
-            "item-placer"
-        );
+            BlockPos blockPos = hit.getBlockPos();
 
+            double x = Math.abs(xT - blockPos.getX());
+            double y = Math.abs(yT - blockPos.getY());
+            double z = Math.abs(zT - blockPos.getZ());
 
-        KeyMappingRegistry.register(PLACE_KEY);
-        KeyMappingRegistry.register(STOP_SCROLLING_KEY);
-        KeyMappingRegistry.register(RETRIEVE_KEY);
+            Vec3d pos = new Vec3d(x,y,z);
 
-        ClientTickEvent.CLIENT_POST.register(client -> {
-            if (PLACE_KEY.wasPressed()) {
-                if (client.crosshairTarget instanceof BlockHitResult && client.player.getStackInHand(Hand.MAIN_HAND) != ItemStack.EMPTY && MinecraftClient.getInstance().world.getBlockState(((BlockHitResult) client.crosshairTarget).getBlockPos()).getBlock() != Blocks.AIR) {
-                    PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
-                    Direction side = ((BlockHitResult) client.crosshairTarget).getSide();
-                    BlockPos pos = ((BlockHitResult) client.crosshairTarget).getBlockPos();
-                    buf.writeBlockPos(pos.offset(side, 1));
-                    buf.writeBlockHitResult((BlockHitResult) client.crosshairTarget);
-                    NetworkManager.sendToServer(ITEMPLACE, buf);
+            for (int i = 0; i < boxes.size(); i++) {
+                if (contains(pos, boxes.get(i))) {
+                    return i;
                 }
             }
-        });
-    }
-
-    public static int dirToInt(Direction dir) {
-        return switch (dir) {
-            case SOUTH -> 0;
-            case NORTH -> 1;
-            case EAST -> 2;
-            case WEST -> 3;
-            case UP -> 4;
-            case DOWN -> 5;
-        };
-    }
-
-    public static Direction intToDir(int dir) {
-        return switch (dir) {
-            case 0 -> Direction.SOUTH;
-            case 1 -> Direction.NORTH;
-            case 2 -> Direction.EAST;
-            case 3 -> Direction.WEST;
-            case 4 -> Direction.UP;
-            case 5 -> Direction.DOWN;
-            default -> throw new IllegalStateException("Unexpected value: " + dir);
-        };
-    }
-
-    static boolean contains(Vec3d vec, Box box) {
-        return vec.x >= box.minX
-            && vec.x <= box.maxX
-            && vec.y >= box.minY
-            && vec.y <= box.maxY
-            && vec.z >= box.minZ
-            && vec.z <= box.maxZ;
-    }
-
-    static List<Box> boxes = new ArrayList<>(
-        List.of(
-            new Box(0.125f, 0.125f, 0.875f, 0.875f, 0.875f, 1.0f),
-            new Box(0.125f, 0.125f, 0.0f, 0.875f, 0.875f, 0.125f),
-            new Box(0.875f, 0.125f, 0.125f, 1.0f, 0.875f, 0.875f),
-            new Box(0.0f, 0.125f, 0.125f, 0.125f, 0.875f, 0.875f),
-            new Box(0.125f, 0.875f, 0.125f, 0.875f, 1.0f, 0.875f),
-            new Box(0.125f, 0.0f, 0.125f, 0.875f, 0.125f, 0.875f)
-        )
-    );
-
-    public static int getDirection(BlockHitResult hit) {
-        double xT = hit.getPos().x;
-        double yT = hit.getPos().y;
-        double zT = hit.getPos().z;
-
-        BlockPos blockPos = hit.getBlockPos();
-
-        double x = Math.abs(xT - blockPos.getX());
-        double y = Math.abs(yT - blockPos.getY());
-        double z = Math.abs(zT - blockPos.getZ());
-
-        Vec3d pos = new Vec3d(x,y,z);
-
-        for (int i = 0; i < boxes.size(); i++) {
-            if (contains(pos, boxes.get(i))) {
-                return i;
-            }
+            LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
+            return 0;
         }
-        LOGGER.warn("Somehow you got warning? damn... Maybe my mod is fucking garbage? (item-placer)");
-        return 0;
-    }
 }

--- a/common/src/main/java/com/akicater/blocks/layingItem.java
+++ b/common/src/main/java/com/akicater/blocks/layingItem.java
@@ -113,7 +113,7 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
 
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView blockView, BlockPos pos, ShapeContext context) {
-        if (!RETRIEVE_KEY.isUnbound() && !RETRIEVE_KEY.isPressed())
+        if (!RETRIEVE_KEY.isUnbound() && !RETRIEVE_KEY.isPressed() && !STOP_SCROLLING_KEY.isPressed())
             return VoxelShapes.empty();
         layingItemBlockEntity entity = (layingItemBlockEntity) blockView.getBlockEntity(pos);
         List<VoxelShape> tempShape = new ArrayList<>();

--- a/common/src/main/java/com/akicater/blocks/layingItem.java
+++ b/common/src/main/java/com/akicater/blocks/layingItem.java
@@ -69,21 +69,25 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
     public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
         layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
         if (blockEntity != null && (RETRIEVE_KEY.isUnbound() || RETRIEVE_KEY.isPressed())) {
-            blockEntity.dropItem(getDirection(hit));
-            if (isInventoryClear(blockEntity.inventory)) {
-                if (state.get(WATERLOGGED)) {
-                    world.setBlockState(pos, Blocks.WATER.getDefaultState());
-                } else {
-                    world.setBlockState(pos, Blocks.AIR.getDefaultState());
-                }
-            }
-            world.playSound(pos.getX(), pos.getY(), pos.getZ(), SoundEvents.ENTITY_PAINTING_PLACE, SoundCategory.BLOCKS, 1f, 2f, true);
+            retrieveItem(state, world, pos, hit, blockEntity);
             return ActionResult.SUCCESS;
         }
         return ActionResult.FAIL;
     }
 
-    Boolean isInventoryClear(DefaultedList<ItemStack> inventory) {
+    public static void retrieveItem(BlockState state, World world, BlockPos pos, BlockHitResult hit, layingItemBlockEntity blockEntity) {
+        blockEntity.dropItem(getDirection(hit));
+        if (isInventoryClear(blockEntity.inventory)) {
+            if (state.get(WATERLOGGED)) {
+                world.setBlockState(pos, Blocks.WATER.getDefaultState());
+            } else {
+                world.setBlockState(pos, Blocks.AIR.getDefaultState());
+            }
+        }
+        world.playSound(pos.getX(), pos.getY(), pos.getZ(), SoundEvents.ENTITY_PAINTING_PLACE, SoundCategory.BLOCKS, 1f, 2f, true);
+    }
+
+    private static Boolean isInventoryClear(DefaultedList<ItemStack> inventory) {
         for (ItemStack itemStack : inventory) {
             if (!ItemStack.EMPTY.equals(itemStack)) {
                 return false;

--- a/common/src/main/java/com/akicater/blocks/layingItem.java
+++ b/common/src/main/java/com/akicater/blocks/layingItem.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.akicater.ItemPlacerCommon.getDirection;
+import static com.akicater.ItemPlacerCommon.*;
 
 public class layingItem extends Block implements Waterloggable, BlockEntityProvider {
     public static BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
@@ -42,7 +42,8 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
     }
 
     public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
-        if (state.get(WATERLOGGED)) world.scheduleFluidTick(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
+        if (state.get(WATERLOGGED))
+            world.createAndScheduleFluidTick(pos, Fluids.WATER, Fluids.WATER.getTickRate(world));
 
         return super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);
     }
@@ -62,8 +63,8 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
 
     @Override
     public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
-        layingItemBlockEntity blockEntity = (layingItemBlockEntity)world.getChunk(pos).getBlockEntity(pos);
-        if (blockEntity != null) {
+        layingItemBlockEntity blockEntity = (layingItemBlockEntity) world.getChunk(pos).getBlockEntity(pos);
+        if (blockEntity != null && (RETRIEVE_KEY.isUnbound() || RETRIEVE_KEY.isPressed())) {
             blockEntity.dropItem(getDirection(hit));
             if (isInventoryClear(blockEntity.inventory)) {
                 if (state.get(WATERLOGGED)) {
@@ -112,6 +113,8 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
 
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView blockView, BlockPos pos, ShapeContext context) {
+        if (!RETRIEVE_KEY.isUnbound() && !RETRIEVE_KEY.isPressed())
+            return VoxelShapes.empty();
         layingItemBlockEntity entity = (layingItemBlockEntity) blockView.getBlockEntity(pos);
         List<VoxelShape> tempShape = new ArrayList<>();
         if (entity != null) {

--- a/common/src/main/java/com/akicater/blocks/layingItem.java
+++ b/common/src/main/java/com/akicater/blocks/layingItem.java
@@ -57,6 +57,10 @@ public class layingItem extends Block implements Waterloggable, BlockEntityProvi
     }
 
     @Override
+    protected void spawnBreakParticles(World world, PlayerEntity player, BlockPos pos, BlockState state) {
+    }
+
+    @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
         return new layingItemBlockEntity(pos, state);
     }

--- a/common/src/main/java/com/akicater/blocks/layingItemBlockEntity.java
+++ b/common/src/main/java/com/akicater/blocks/layingItemBlockEntity.java
@@ -9,8 +9,8 @@ import net.minecraft.inventory.Inventories;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.network.Packet;
 import net.minecraft.network.listener.ClientPlayPacketListener;
-import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ItemScatterer;
@@ -62,6 +62,8 @@ public class layingItemBlockEntity extends BlockEntity {
             world.updateComparators(pos, LAYING_ITEM.get());
         }
     }
+
+
 
     public layingItemBlockEntity(BlockPos pos, BlockState state) {
         super(ItemPlacerCommon.LAYING_ITEM_BLOCK_ENTITY.get(), pos, state);

--- a/common/src/main/java/com/akicater/blocks/layingItemBlockEntity.java
+++ b/common/src/main/java/com/akicater/blocks/layingItemBlockEntity.java
@@ -63,8 +63,6 @@ public class layingItemBlockEntity extends BlockEntity {
         }
     }
 
-
-
     public layingItemBlockEntity(BlockPos pos, BlockState state) {
         super(ItemPlacerCommon.LAYING_ITEM_BLOCK_ENTITY.get(), pos, state);
     }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -42,9 +42,10 @@ dependencies {
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 
-    modApi("me.shedaniel.cloth:cloth-config-fabric:${cloth_config}") {
-        exclude(group: "net.fabricmc.fabric-api")
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${cloth_config}")  {
+        exclude group: 'net.fabricmc', module: 'fabric-loader'
     }
+
     modImplementation("com.terraformersmc:modmenu:${modmenu_version}")
 }
 

--- a/fabric/src/main/java/com/akicater/fabric/client/ItemPlacerConfig.java
+++ b/fabric/src/main/java/com/akicater/fabric/client/ItemPlacerConfig.java
@@ -11,4 +11,5 @@ public class ItemPlacerConfig implements ConfigData {
     public float tempItemSize = 1.0f;
     public float tempBlockSize = 1.0f;
     public boolean oldRendering = false;
+    public float blockDepthOffset = 0f;
 }

--- a/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
+++ b/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
@@ -8,16 +8,16 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.RotationAxis;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Quaternion;
+import net.minecraft.util.math.Vec3f;
 import net.minecraft.world.LightType;
 import net.minecraft.world.World;
-import org.joml.Math;
-import org.joml.Quaternionf;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,14 +26,14 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
 
     ItemPlacerConfig config = AutoConfig.getConfigHolder(ItemPlacerConfig.class).getConfig();
 
-    public static List<Quaternionf> list = new ArrayList<>(
+    public static List<Quaternion> list = new ArrayList<>(
             List.of(
-                    RotationAxis.POSITIVE_X.rotationDegrees(0),   //SOUTH
-                    RotationAxis.POSITIVE_Y.rotationDegrees(180),   //NORTH
-                    RotationAxis.POSITIVE_Y.rotationDegrees(90),    //EAST
-                    RotationAxis.NEGATIVE_Y.rotationDegrees(90),    //WEST
-                    RotationAxis.NEGATIVE_X.rotationDegrees(90),    //UP
-                    RotationAxis.POSITIVE_X.rotationDegrees(90)    //DOWN
+                Vec3f.POSITIVE_X.getDegreesQuaternion(0),   //SOUTH
+                Vec3f.POSITIVE_Y.getDegreesQuaternion(180),   //NORTH
+                Vec3f.POSITIVE_Y.getDegreesQuaternion(90),    //EAST
+                Vec3f.NEGATIVE_Y.getDegreesQuaternion(90),    //WEST
+                Vec3f.NEGATIVE_X.getDegreesQuaternion(90),    //UP
+                Vec3f.POSITIVE_X.getDegreesQuaternion(90)    //DOWN
             )
     );
 
@@ -43,22 +43,22 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
         return LightmapTextureManager.pack(world.getLightLevel(LightType.BLOCK, pos), world.getLightLevel(LightType.SKY, pos));
     }
 
-    public Quaternionf rotateZ(float angle, Quaternionf dest) {
-        float sin = Math.sin(angle * 0.5f);
-        float cos = Math.cosFromSin(sin, angle * 0.5f);
-        return new Quaternionf(dest.x * cos + dest.y * sin,
-                dest.y * cos - dest.x * sin,
-                dest.w * sin + dest.z * cos,
-                dest.w * cos - dest.z * sin);
+    public Quaternion rotateZ(float angle, Quaternion dest) {
+        float sin = MathHelper.sin(angle * 0.5f);
+        float cos = MathHelper.sin(angle * 0.5f + 1.5707963267948966f);
+        return new Quaternion(dest.getX() * cos + dest.getY() * sin,
+            dest.getY() * cos - dest.getX() * sin,
+            dest.getW() * sin + dest.getZ() * cos,
+            dest.getW() * cos - dest.getZ() * sin);
     }
 
-    public Quaternionf rotateX(float angle, Quaternionf dest) {
-        float sin = Math.sin(angle * 0.5f);
-        float cos = Math.cosFromSin(sin, angle * 0.5f);
-        return new Quaternionf(dest.w * sin + dest.x * cos,
-                dest.y * cos + dest.z * sin,
-                dest.z * cos - dest.y * sin,
-                dest.w * cos - dest.x * sin);
+    public Quaternion rotateX(float angle, Quaternion dest) {
+        float sin = MathHelper.sin(angle * 0.5f);
+        float cos = MathHelper.sin(angle * 0.5f + 1.5707963267948966f);
+        return new Quaternion(dest.getW() * sin + dest.getX() * cos,
+            dest.getY() * cos + dest.getZ() * sin,
+            dest.getZ() * cos - dest.getY() * sin,
+            dest.getW() * cos - dest.getX() * sin);
     }
 
     @Override
@@ -84,18 +84,18 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 if(item.getItem() instanceof BlockItem) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
-                        matrices.multiply(rotateX(Math.toRadians(-90), rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
+                        matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
                         matrices.translate(0,0.25 * blockSize - 0.025,0);
                     } else {
-                        matrices.multiply(rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                        matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                     }
                     matrices.scale(blockSize, blockSize, blockSize);
                 } else {
                     matrices.scale(itemSize, itemSize, itemSize);
-                    matrices.multiply(rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                    matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                 }
 
-                itemRenderer.renderItem(item, ModelTransformationMode.FIXED, x, overlay, matrices,vertexConsumers, entity.getWorld(),1);
+                itemRenderer.renderItem(item, ModelTransformation.Mode.FIXED, x, overlay, matrices, vertexConsumers, 1);
 
                 matrices.pop();
             }

--- a/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
+++ b/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
@@ -82,11 +82,12 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 matrices.translate(entity.positions.get(i).x, entity.positions.get(i).y, entity.positions.get(i).z);
 
                 // Differentiate item and block rendering
-                if (item.getItem() instanceof BlockItem && ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos())) {
+                if (item.getItem() instanceof BlockItem && (!oldRendering ||
+                    ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos()))) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
                         matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0, 0.25 * blockSize - 0.025 - config.blockDepthOffset, 0);
+                        matrices.translate(0, 0.25 * blockSize - 0.025, 0);
                     } else {
                         matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                         matrices.translate(0, 0, config.blockDepthOffset);

--- a/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
+++ b/fabric/src/main/java/com/akicater/fabric/client/layingItemBER.java
@@ -2,6 +2,7 @@ package com.akicater.fabric.client;
 
 import com.akicater.blocks.layingItemBlockEntity;
 import me.shedaniel.autoconfig.AutoConfig;
+import net.minecraft.block.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -10,8 +11,7 @@ import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Quaternion;
@@ -27,19 +27,20 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
     ItemPlacerConfig config = AutoConfig.getConfigHolder(ItemPlacerConfig.class).getConfig();
 
     public static List<Quaternion> list = new ArrayList<>(
-            List.of(
-                Vec3f.POSITIVE_X.getDegreesQuaternion(0),   //SOUTH
-                Vec3f.POSITIVE_Y.getDegreesQuaternion(180),   //NORTH
-                Vec3f.POSITIVE_Y.getDegreesQuaternion(90),    //EAST
-                Vec3f.NEGATIVE_Y.getDegreesQuaternion(90),    //WEST
-                Vec3f.NEGATIVE_X.getDegreesQuaternion(90),    //UP
-                Vec3f.POSITIVE_X.getDegreesQuaternion(90)    //DOWN
-            )
+        List.of(
+            Vec3f.POSITIVE_X.getDegreesQuaternion(0),   //SOUTH
+            Vec3f.POSITIVE_Y.getDegreesQuaternion(180),   //NORTH
+            Vec3f.POSITIVE_Y.getDegreesQuaternion(90),    //EAST
+            Vec3f.NEGATIVE_Y.getDegreesQuaternion(90),    //WEST
+            Vec3f.NEGATIVE_X.getDegreesQuaternion(90),    //UP
+            Vec3f.POSITIVE_X.getDegreesQuaternion(90)    //DOWN
+        )
     );
 
-    public layingItemBER(BlockEntityRendererFactory.Context ctx) {}
+    public layingItemBER(BlockEntityRendererFactory.Context ctx) {
+    }
 
-    static int getLight(World world, BlockPos pos){
+    static int getLight(World world, BlockPos pos) {
         return LightmapTextureManager.pack(world.getLightLevel(LightType.BLOCK, pos), world.getLightLevel(LightType.SKY, pos));
     }
 
@@ -73,7 +74,7 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
         int x = getLight(entity.getWorld(), entity.getPos());
 
         for (int i = 0; i < 6; i++) {
-            if(!entity.inventory.get(i).isEmpty()) {
+            if (!entity.inventory.get(i).isEmpty()) {
                 ItemStack item = entity.inventory.get(i);
 
                 matrices.push();
@@ -81,13 +82,14 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 matrices.translate(entity.positions.get(i).x, entity.positions.get(i).y, entity.positions.get(i).z);
 
                 // Differentiate item and block rendering
-                if(item.getItem() instanceof BlockItem) {
+                if (item.getItem() instanceof BlockItem && ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos())) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
                         matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0,0.25 * blockSize - 0.025,0);
+                        matrices.translate(0, 0.25 * blockSize - 0.025 - config.blockDepthOffset, 0);
                     } else {
                         matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                        matrices.translate(0, 0, config.blockDepthOffset);
                     }
                     matrices.scale(blockSize, blockSize, blockSize);
                 } else {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.1",
-    "minecraft": "~1.20.1",
+    "minecraft": "~1.19.2",
     "java": ">=17",
-    "architectury": ">=9.2.14",
+    "architectury": ">=6.6.92",
     "fabric-api": "*"
   },
   "suggests": {

--- a/forge/src/main/java/com/akicater/forge/ItemPlacerConfig.java
+++ b/forge/src/main/java/com/akicater/forge/ItemPlacerConfig.java
@@ -3,12 +3,11 @@ package com.akicater.forge;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 
-import static com.akicater.ItemPlacerCommon.MODID;
-
 @Config(name = "itemplacer")
 public class ItemPlacerConfig implements ConfigData {
     public float absoluteSize = 0.75f;
     public float tempItemSize = 1.0f;
     public float tempBlockSize = 1.0f;
     public boolean oldRendering = false;
+    public float blockDepthOffset = 0f;
 }

--- a/forge/src/main/java/com/akicater/forge/layingItemBER.java
+++ b/forge/src/main/java/com/akicater/forge/layingItemBER.java
@@ -1,6 +1,5 @@
 package com.akicater.forge;
 
-import com.akicater.ItemPlacerCommon;
 import com.akicater.blocks.layingItemBlockEntity;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.MinecraftClient;
@@ -9,57 +8,57 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
 import net.minecraft.client.render.block.entity.BlockEntityRendererFactory;
 import net.minecraft.client.render.item.ItemRenderer;
-import net.minecraft.client.render.model.json.ModelTransformationMode;
+import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.RotationAxis;
+import net.minecraft.util.math.*;
 import net.minecraft.world.LightType;
 import net.minecraft.world.World;
-import org.joml.Math;
-import org.joml.Quaternionf;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static net.minecraft.util.math.MathHelper.*;
 
 public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity> {
 
     ItemPlacerConfig config = AutoConfig.getConfigHolder(ItemPlacerConfig.class).getConfig();
 
-    public static List<Quaternionf> list = new ArrayList<>(
-            List.of(
-                    RotationAxis.POSITIVE_X.rotationDegrees(0),   //SOUTH
-                    RotationAxis.POSITIVE_Y.rotationDegrees(180),   //NORTH
-                    RotationAxis.POSITIVE_Y.rotationDegrees(90),    //EAST
-                    RotationAxis.NEGATIVE_Y.rotationDegrees(90),    //WEST
-                    RotationAxis.NEGATIVE_X.rotationDegrees(90),    //UP
-                    RotationAxis.POSITIVE_X.rotationDegrees(90)    //DOWN
-            )
+    public static List<Quaternion> list = new ArrayList<>(
+        List.of(
+            Vec3f.POSITIVE_X.getDegreesQuaternion(0),   //SOUTH
+            Vec3f.POSITIVE_Y.getDegreesQuaternion(180),   //NORTH
+            Vec3f.POSITIVE_Y.getDegreesQuaternion(90),    //EAST
+            Vec3f.NEGATIVE_Y.getDegreesQuaternion(90),    //WEST
+            Vec3f.NEGATIVE_X.getDegreesQuaternion(90),    //UP
+            Vec3f.POSITIVE_X.getDegreesQuaternion(90)    //DOWN
+        )
     );
 
-    public layingItemBER(BlockEntityRendererFactory.Context ctx) {}
+    public layingItemBER(BlockEntityRendererFactory.Context ctx) {
+    }
 
-    static int getLight(World world, BlockPos pos){
+    static int getLight(World world, BlockPos pos) {
         return LightmapTextureManager.pack(world.getLightLevel(LightType.BLOCK, pos), world.getLightLevel(LightType.SKY, pos));
     }
 
-    public Quaternionf rotateZ(float angle, Quaternionf dest) {
-        float sin = Math.sin(angle * 0.5f);
-        float cos = Math.cosFromSin(sin, angle * 0.5f);
-        return new Quaternionf(dest.x * cos + dest.y * sin,
-                dest.y * cos - dest.x * sin,
-                dest.w * sin + dest.z * cos,
-                dest.w * cos - dest.z * sin);
+    public Quaternion rotateZ(float angle, Quaternion dest) {
+        float sin = MathHelper.sin(angle * 0.5f);
+        float cos = MathHelper.sin(angle * 0.5f + 1.5707963267948966f);
+        return new Quaternion(dest.getX() * cos + dest.getY() * sin,
+            dest.getY() * cos - dest.getX() * sin,
+            dest.getW() * sin + dest.getZ() * cos,
+            dest.getW() * cos - dest.getZ() * sin);
     }
 
-    public Quaternionf rotateX(float angle, Quaternionf dest) {
-        float sin = Math.sin(angle * 0.5f);
-        float cos = Math.cosFromSin(sin, angle * 0.5f);
-        return new Quaternionf(dest.w * sin + dest.x * cos,
-                dest.y * cos + dest.z * sin,
-                dest.z * cos - dest.y * sin,
-                dest.w * cos - dest.x * sin);
+    public Quaternion rotateX(float angle, Quaternion dest) {
+        float sin = MathHelper.sin(angle * 0.5f);
+        float cos = MathHelper.sin(angle * 0.5f + 1.5707963267948966f);
+        return new Quaternion(dest.getW() * sin + dest.getX() * cos,
+            dest.getY() * cos + dest.getZ() * sin,
+            dest.getZ() * cos - dest.getY() * sin,
+            dest.getW() * cos - dest.getX() * sin);
     }
 
     @Override
@@ -74,7 +73,7 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
         int x = getLight(entity.getWorld(), entity.getPos());
 
         for (int i = 0; i < 6; i++) {
-            if(!entity.inventory.get(i).isEmpty()) {
+            if (!entity.inventory.get(i).isEmpty()) {
                 ItemStack item = entity.inventory.get(i);
 
                 matrices.push();
@@ -82,21 +81,21 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 matrices.translate(entity.positions.get(i).x, entity.positions.get(i).y, entity.positions.get(i).z);
 
                 // Differentiate item and block rendering
-                if(item.getItem() instanceof BlockItem) {
+                if (item.getItem() instanceof BlockItem) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
-                        matrices.multiply(rotateX(Math.toRadians(-90), rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0,0.25 * blockSize - 0.025,0);
+                        matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
+                        matrices.translate(0, 0.25 * blockSize - 0.025, 0);
                     } else {
-                        matrices.multiply(rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                        matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                     }
                     matrices.scale(blockSize, blockSize, blockSize);
                 } else {
                     matrices.scale(itemSize, itemSize, itemSize);
-                    matrices.multiply(rotateZ(Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                    matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                 }
 
-                itemRenderer.renderItem(item, ModelTransformationMode.FIXED, x, overlay, matrices,vertexConsumers, entity.getWorld(),1);
+                itemRenderer.renderItem(item, ModelTransformation.Mode.FIXED, x, overlay, matrices, vertexConsumers, 1);
 
                 matrices.pop();
             }

--- a/forge/src/main/java/com/akicater/forge/layingItemBER.java
+++ b/forge/src/main/java/com/akicater/forge/layingItemBER.java
@@ -19,8 +19,6 @@ import net.minecraft.world.World;
 import java.util.ArrayList;
 import java.util.List;
 
-import static net.minecraft.util.math.MathHelper.*;
-
 public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity> {
 
     ItemPlacerConfig config = AutoConfig.getConfigHolder(ItemPlacerConfig.class).getConfig();
@@ -85,9 +83,10 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
                         matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0, 0.25 * blockSize - 0.025, 0);
+                        matrices.translate(0, 0.25 * blockSize - 0.025, config.blockDepthOffset);
                     } else {
                         matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
+                        matrices.translate(0, 0, config.blockDepthOffset);
                     }
                     matrices.scale(blockSize, blockSize, blockSize);
                 } else {

--- a/forge/src/main/java/com/akicater/forge/layingItemBER.java
+++ b/forge/src/main/java/com/akicater/forge/layingItemBER.java
@@ -79,11 +79,12 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 matrices.translate(entity.positions.get(i).x, entity.positions.get(i).y, entity.positions.get(i).z);
 
                 // Differentiate item and block rendering
-                if (item.getItem() instanceof BlockItem && ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos())) {
+                if (item.getItem() instanceof BlockItem && (!oldRendering ||
+                        ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos()))) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
                         matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0, 0.25 * blockSize - 0.025 - config.blockDepthOffset, 0);
+                        matrices.translate(0, 0.25 * blockSize - 0.025, 0);
                     } else {
                         matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                         matrices.translate(0, 0, config.blockDepthOffset);

--- a/forge/src/main/java/com/akicater/forge/layingItemBER.java
+++ b/forge/src/main/java/com/akicater/forge/layingItemBER.java
@@ -79,11 +79,11 @@ public class layingItemBER implements BlockEntityRenderer<layingItemBlockEntity>
                 matrices.translate(entity.positions.get(i).x, entity.positions.get(i).y, entity.positions.get(i).z);
 
                 // Differentiate item and block rendering
-                if (item.getItem() instanceof BlockItem) {
+                if (item.getItem() instanceof BlockItem && ((BlockItem) item.getItem()).getBlock().getDefaultState().isFullCube(entity.getWorld(), entity.getPos())) {
                     // Differentiate new and old block rendering
                     if (!oldRendering) {
                         matrices.multiply(rotateX((float) Math.toRadians(-90), rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i))));
-                        matrices.translate(0, 0.25 * blockSize - 0.025, config.blockDepthOffset);
+                        matrices.translate(0, 0.25 * blockSize - 0.025 - config.blockDepthOffset, 0);
                     } else {
                         matrices.multiply(rotateZ((float) Math.toRadians(entity.rotation.list.get(i)), list.get(i)));
                         matrices.translate(0, 0, config.blockDepthOffset);

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[47,)"
+loaderVersion = "[43,)"
 #issueTrackerURL = ""
 license = "Insert License Here"
 
@@ -16,20 +16,20 @@ logoFile = "assets/item-placer/logo.png"
 [[dependencies.itemplacer]]
 modId = "forge"
 mandatory = true
-versionRange = "[47,)"
+versionRange = "[43,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.itemplacer]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.20.1,)"
+versionRange = "[1.19.2,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.itemplacer]]
 modId = "architectury"
 mandatory = true
-versionRange = "[9.2.14,)"
+versionRange = "[6.6.92,)"
 ordering = "AFTER"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,14 +9,14 @@ archives_name = itemplacer
 enabled_platforms = fabric,forge
 
 # Minecraft properties
-minecraft_version = 1.20.1
-yarn_mappings = 1.20.1+build.1
+minecraft_version = 1.19.2
+yarn_mappings = 1.19.2+build.28
 
 # Dependencies
-architectury_api_version = 9.2.14
-fabric_loader_version = 0.16.2
-fabric_api_version = 0.92.2+1.20.1
-forge_version = 1.20.1-47.3.3
+architectury_api_version = 6.6.92
+fabric_loader_version = 0.16.5
+fabric_api_version = 0.77.0+1.19.2
+forge_version = 1.19.2-43.4.2
 
-modmenu_version = 7.2.2
-cloth_config = 11.1.118
+modmenu_version = 4.1.2
+cloth_config = 8.3.134


### PR DESCRIPTION
Hello there 👋 

I've ported your great mod to 1.19.2.
In additon to that I made some minor additions/adaptions:

- a new key binding to retrieve the item from a block (reasoning in the next point)
- return an empty shape for the `layingItem` if no key is pressed, to use placed items as a storage label (clicking on the item will let players open the block behind - like chests and barrels).
- old rendering: added a configurable block offset, so that placed blocks and items can protrude equally
- old rendering: only use block rendering for full cubes so that a `CarrotBlock` is rendered lay down and in the same size just like other items such as apples

Sorry for the new formatting of `ItemPlacerCommon` - it was changed automatically right after the checkout of the original branch
(even if I added a further indent like in the original file, the lines were marked as changed).